### PR TITLE
fix: Build warnings

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -84,7 +84,7 @@ impl<S: PartialEq + Copy> ResultColumn<S> {
                             name.replace_range(
                                 name.char_indices()
                                     .nth(idx + 2)
-                                    .map(|(pos, ch)| (pos..pos + ch.len_utf8()))
+                                    .map(|(pos, ch)| pos..pos + ch.len_utf8())
                                     .unwrap(),
                                 match dir {
                                     SortDir::Asc => "▲",

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -140,7 +140,7 @@ pub fn centered_rect(mut x_len: u16, mut y_len: u16, r: Rect) -> Rect {
     .split(popup_layout[1])[1]
 }
 
-pub fn border_block(theme: &Theme, focused: bool) -> Block {
+pub fn border_block(theme: &Theme, focused: bool) -> Block<'_> {
     Block::new()
         .border_style(match focused {
             true => style!(fg:theme.border_focused_color),


### PR DESCRIPTION
Gets rid of these:
```
warning: unnecessary parentheses around closure body
  --> src\results.rs:87:54
   |
87 | ...                   .map(|(pos, ch)| (pos..pos + ch.len_utf8()))
   |                                        ^                        ^
   |
   = note: `#[warn(unused_parens)]` (part of `#[warn(unused)]`) on by default
help: remove these parentheses
   |
87 -                                     .map(|(pos, ch)| (pos..pos + ch.len_utf8()))
87 +                                     .map(|(pos, ch)| pos..pos + ch.len_utf8() )
   |

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src\widget.rs:143:28
    |
143 | pub fn border_block(theme: &Theme, focused: bool) -> Block {
    |                            ^^^^^^                    ^^^^^ the same lifetime is hidden here
    |                            |
    |                            the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
143 | pub fn border_block(theme: &Theme, focused: bool) -> Block<'_> {
    |                                                           ++++

warning: `nyaa` (lib) generated 2 warnings (run `cargo fix --lib -p nyaa` to apply 2 suggestions)
warning: `nyaa` (bin "nyaa") generated 2 warnings (2 duplicates)
```